### PR TITLE
[fix] compatibility with peewee 2.8.2

### DIFF
--- a/pypi_server/db/__init__.py
+++ b/pypi_server/db/__init__.py
@@ -9,7 +9,7 @@ from playhouse.migrate import SqliteMigrator, MySQLMigrator, PostgresqlMigrator
 DB = Proxy()
 
 
-class Model(SignalsModel):
+class BaseModel(SignalsModel):
     class Meta:
         database = DB
 

--- a/pypi_server/db/migrator/model.py
+++ b/pypi_server/db/migrator/model.py
@@ -1,9 +1,9 @@
 # encoding: utf-8
 import datetime
 import peewee
-from pypi_server.db import Model
+from pypi_server.db import BaseModel
 
 
-class Migrations(Model):
+class Migrations(BaseModel):
     name = peewee.CharField(max_length=255, null=False, index=True, unique=True)
     ts = peewee.DateTimeField(default=datetime.datetime.now, null=False)

--- a/pypi_server/db/packages.py
+++ b/pypi_server/db/packages.py
@@ -13,7 +13,7 @@ from playhouse import signals
 from pypi_server.cache import Cache
 from pypi_server.timeit import timeit
 from pypi_server.hash_version import HashVersion
-from pypi_server.db import Model
+from pypi_server.db import BaseModel
 from pypi_server.db.users import Users
 from tornado.ioloop import IOLoop
 
@@ -78,7 +78,7 @@ class FileField(p.CharField):
         )
 
 
-class Package(Model):
+class Package(BaseModel):
     name = p.CharField(index=True)
     lower_name = p.CharField(index=True, unique=True)
     owner = p.ForeignKeyField(Users, null=True, index=True)
@@ -214,7 +214,7 @@ class Package(Model):
 
 
 @total_ordering
-class PackageVersion(Model):
+class PackageVersion(BaseModel):
     package = p.ForeignKeyField(Package, index=True, null=False)
     version = VersionField(index=True, null=False)
     hidden = p.BooleanField(default=False, null=False, index=True)
@@ -299,7 +299,7 @@ class PackageVersion(Model):
         return "%s" % self.version
 
 
-class PackageFile(Model):
+class PackageFile(BaseModel):
     LOCK = RLock()
     CHUNK_SIZE = 2 ** 16
 

--- a/pypi_server/db/rules.py
+++ b/pypi_server/db/rules.py
@@ -1,11 +1,11 @@
 # encoding: utf-8
 import peewee as p
-from pypi_server.db import Model
+from pypi_server.db import BaseModel
 from pypi_server.db.users import Users
 from playhouse.fields import ManyToManyField
 
 
-class Groups(Model):
+class Groups(BaseModel):
     name = p.CharField(max_length=255, unique=True, index=True, null=False)
     disabled = p.BooleanField(default=False, null=False)
 
@@ -25,7 +25,7 @@ class Groups(Model):
             raise p.DoesNotExist("User doesn't exists")
 
 
-class Participant(Model):
+class Participant(BaseModel):
     user = p.ForeignKeyField(Users, unique=False, index=True)
     group = p.ForeignKeyField(Groups, unique=False, index=True)
     rules = ManyToManyField()

--- a/pypi_server/db/users.py
+++ b/pypi_server/db/users.py
@@ -3,7 +3,7 @@
 import peewee as p
 from six import binary_type, text_type
 from playhouse.fields import gensalt, hashpw
-from pypi_server.db import Model
+from pypi_server.db import BaseModel
 from tornado.log import app_log as log
 
 
@@ -59,7 +59,7 @@ class PasswordField(p.TextField):
         return PasswordHash(u(value))
 
 
-class Users(Model):
+class Users(BaseModel):
     login = p.CharField(max_length=255, unique=True, index=True, null=False)
     password = PasswordField(iterations=10, null=False)
     disabled = p.BooleanField(default=False, null=False)

--- a/setup.py
+++ b/setup.py
@@ -80,7 +80,7 @@ setup(
         'tornado>=4.3',
         'tornado-xmlrpc',
         'slimurl',
-        'peewee<2.8',
+        'peewee',
         'bcrypt>=2.0',
         'lxml',
         'futures',


### PR DESCRIPTION
This PR fixes compatibility with peewee 2.8.2.

A class inheriting from playhouse.signals.Model cannot be named Model because of a bug introduced in https://github.com/coleifer/peewee/commit/6b7c013a8923c8786b4ed815e934072c90b55a13