### PR TITLE
HTTP proxy support

### DIFF
--- a/pypi_server/handlers/pypi/package.py
+++ b/pypi_server/handlers/pypi/package.py
@@ -46,7 +46,6 @@ def write_file(pkg_file, data):
 @route(r"/package/(?P<package>\S+)/(?P<version>\S+)/(?P<filename>\S+)")
 class FileHandler(BaseHandler):
     CHUNK_SIZE = 2 ** 16
-    HTTP_CLIENT = AsyncHTTPClient()
 
     @asynchronous
     @HTTPCache(MONTH, use_expires=True, expire_timeout=MONTH)
@@ -112,7 +111,7 @@ class FileHandler(BaseHandler):
     @classmethod
     @coroutine
     def fetch_remote_file(cls, pkg_file):
-        response = yield cls.HTTP_CLIENT.fetch(pkg_file.url)
+        response = yield AsyncHTTPClient().fetch(pkg_file.url)
         yield write_file(pkg_file, response.body)
 
 

--- a/pypi_server/server.py
+++ b/pypi_server/server.py
@@ -159,6 +159,19 @@ def run():
 
         AsyncHTTPClient.configure(None, max_clients=options.max_http_clients)
 
+        proxy_url = URL(os.getenv('{0}_proxy'.format(options.pypi_server.scheme)))
+        if proxy_url:
+            log.debug("Configuring for proxy: %s", proxy_url)
+            AsyncHTTPClient.configure(
+                    'tornado.curl_httpclient.CurlAsyncHTTPClient',
+                    defaults={
+                        'proxy_host': proxy_url.host,
+                        'proxy_port': proxy_url.port,
+                        'proxy_username': proxy_url.user,
+                        'proxy_password': proxy_url.password,
+                        }
+                    )
+
         PYPIClient.configure(
             options.pypi_server,
             handlers.base.BaseHandler.THREAD_POOL

--- a/setup.py
+++ b/setup.py
@@ -89,5 +89,6 @@ setup(
     extras_require={
         'mysql': ['mysql-python'],
         'postgres': ['psycopg2'],
+        'proxy': ['pycurl'],
     }
 )


### PR DESCRIPTION
This PR adds support for using pypi-server behind an HTTP proxy through the standard environment variables http_proxy or https_proxy (depending on the scheme of the PyPI index URL).
