### PR TITLE
Allow setting username and password from env

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,10 @@ services:
       # Database URL. Use `sqlite3:///` or `mysql://` when needed
       DB: "postgres://pypi-server:pypi-server@db/pypi-server"
 
+      ## if you want to set PGUSER and PGPASSWORD in env 
+
+      #PGUSER: pypi-server
+      #PGPASSWORD: pypi-server
       ## By default random
       #SECRET: changeme
 

--- a/pypi_server/db/__init__.py
+++ b/pypi_server/db/__init__.py
@@ -60,8 +60,8 @@ def init_postgres(url):
 
     DB.initialize(PostgresqlDatabase(
         database=db_name,
-        user=url.user or '',
-        password=url.password or '',
+        user=url.user or None,
+        password=url.password or None,
         host=url.host,
         autocommit=bool(url.get('autocommit', True)),
         autorollback=bool(url.get('autorollback', True))


### PR DESCRIPTION
I wanted to use azure postgres sql, that database requires to have usernames in the format `<username>@<host>`

The slimurl lib is not recognizing this url pattern so I wanted to set the username and pass from the env variables

