### PR TITLE
Use docker as it is supposed to be used for building from source

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,3 @@
+.git/
 dist/
 build/

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,2 @@
-*
-!dist/*.rpm
+dist/
+build/

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,10 @@ RUN set -ex \
 		libxml2-dev \
 		libxslt-dev \
 		curl-dev \
+	&& pip install \
+		PyMySQL \
 	&& python setup.py install --prefix=/usr/local \
+	&& rm -rf /usr/local/src/{*,.*??} \
 	&& find /usr/local -depth \
 	\( -type f -a -name '*.pyc' -o -name '*.pyo' \) \
 	-exec rm -rf '{}' + \
@@ -28,9 +31,10 @@ RUN set -ex \
 		  | xargs -r apk info --installed \
 		  | sort -u \
 		)" \
-	&& apk add --virtual .pypi-server-rundeps $runDeps \
-	&& apk del .build-deps \
-	&& rm -rf ~/.cache
+	&& apk add --no-cache --virtual .pypi-server-rundeps \
+		$runDeps \
+		py-psycopg2 \
+	&& apk del .build-deps
 
 VOLUME "/usr/lib/pypi-server"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,41 @@
-FROM centos:centos7
-
-COPY dist/pypi-server*.rpm /tmp/
-RUN yum localinstall -y /tmp/*.rpm
-RUN mkdir -p /usr/lib/pypi-server
-RUN yum clean all && rm -fr /tmp/*
+FROM python:2.7-alpine
+MAINTAINER Mosquito <me@mosquito.su>
 
 ENV ADDRESS=0.0.0.0
 ENV PORT=80
 ENV STORAGE=/usr/lib/pypi-server
 
+COPY ./ /usr/local/src
+
+WORKDIR /usr/local/src
+RUN set -ex \
+	&& apk add --no-cache --virtual .build-deps \
+		gcc \
+		libffi-dev \
+		openssl-dev \
+		musl-dev \
+		libxml2-dev \
+		libxslt-dev \
+		curl-dev \
+	&& python setup.py install --prefix=/usr/local \
+	&& find /usr/local -depth \
+	\( -type f -a -name '*.pyc' -o -name '*.pyo' \) \
+	-exec rm -rf '{}' + \
+	&& runDeps="$( \
+		scanelf --needed --nobanner --recursive /usr/local \
+		  | awk '{ gsub(/,/, "\nso:", $2); print "so:" $2 }' \
+		  | sort -u \
+		  | xargs -r apk info --installed \
+		  | sort -u \
+		)" \
+	&& apk add --virtual .pypi-server-rundeps $runDeps \
+	&& apk del .build-deps \
+	&& rm -rf ~/.cache
+
 VOLUME "/usr/lib/pypi-server"
 
-ENTRYPOINT /usr/bin/pypi-server
+COPY docker-entrypoint.sh /entrypoint.sh
 
+EXPOSE 80
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+# if command starts with an option or something that is not executable, prepend pypi-server
+if [ "${1:0:1}" = '-' ] || ! which "${1}" >/dev/null; then
+  set -- pypi-server "$@"
+fi
+
+exec "$@"


### PR DESCRIPTION
The current ``Dockerfile`` uses precompiled local binaries which is not quite the way it should be. When building the docker image the application should be built from source. Thanks to @jgiannuzzi there was already a very clean and slim way to do this with a Python 2.7 Alpine image (see https://github.com/jgiannuzzi/docker-pypi-server/blob/master/Dockerfile).

Sure, one could use ``jgiannuzzi/pypi-server`` but I firmly believe that it would be better if the application author maintains a correct Docker setup. Therefore I am creating a PR using the application sources in the repository to build the image - @jgiannuzzi uses the release on PyPI.

@mosquito this also allows you to link the GitHub repo directly to Docker Hub and automatically build pypi-server images from master and release tags.

Furthermore it totally makes sense to use a slim base image based on Alpine instead of a bigger one like CentOS, etc. For this application to run Alpine is 100% sufficient and keeps the final image small.

For now I linked my fork to build automated images on https://hub.docker.com/r/25thfloor/mosquito-pypi-server/ - feel free to have look. Of course I'd prefer if @mosquito accepts the PR and I can delete this image afterwards and use the "official" one.
