### PR TITLE
[Fix] Postgres and MySQL tried to use default port instead of the provided one in uri

### DIFF
--- a/pypi_server/db/__init__.py
+++ b/pypi_server/db/__init__.py
@@ -46,6 +46,7 @@ def init_mysql(url):
         user=url.user or '',
         password=url.password or '',
         host=url.host,
+        port=url.port,
         autocommit=bool(url.get('autocommit', True)),
         autorollback=bool(url.get('autorollback', True))
     ))
@@ -63,6 +64,7 @@ def init_postgres(url):
         user=url.user or None,
         password=url.password or None,
         host=url.host,
+        port=url.port,
         autocommit=bool(url.get('autocommit', True)),
         autorollback=bool(url.get('autorollback', True))
     ))


### PR DESCRIPTION
With managed databases (AWS, DigitalOcean, etc) it's not able to execute migration/init_db. `check_port` uses the right port, but `init_*` does not.