### PR TITLE
[fix]: postgresql migrations apply

### DIFF
--- a/pypi_server/db/migrator/migrations/005_packagefile_basename_unique.py
+++ b/pypi_server/db/migrator/migrations/005_packagefile_basename_unique.py
@@ -6,9 +6,9 @@ from pypi_server.db.migrator import migration
 
 @migration(8)
 def add_uniquie_basename_index(migrator, db):
-    # Index already exists from previous migrations
-    if isinstance(db, PostgresqlDatabase):
-        pass
+    if isinstance(db.obj, PostgresqlDatabase):
+        # Index already exists from previous migrations
+        return
     try:
         migrate(
             migrator.add_index('packagefile', ('basename',), True)


### PR DESCRIPTION
@mosquito  Sorry  , I was too quick to open the previous PR without checking everything even locally 🤦.
Instead of `PASS`, it should have been `RETURN`, but also the DB type on my environment is in the `db.obj` attribute. Now my `fix` seems work.

PS. Could you, on occasion, update your docker image? :)